### PR TITLE
add node-bencode to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Should return the amount of bytes needed to encode `obj`.
 * [uint64be](https://github.com/mafintosh/uint64be)
 * [uint48be](https://github.com/mafintosh/uint48be)
 * [mp4-box-encoding](https://github.com/jhiesey/mp4-box-encoding)
+* [bencode](https://github.com/themasch/node-bencode)
 
 ## License
 


### PR DESCRIPTION
Added bencode because we now support abstract-encoding (0.8.0)
